### PR TITLE
use -march for portability

### DIFF
--- a/TestMath/Makefile.gcc_Ofast
+++ b/TestMath/Makefile.gcc_Ofast
@@ -1,6 +1,6 @@
 BINS=testexp testlog testpow testroot testtrigon testdiv testintdiv
 
-CXXFLAGS+=-I..  -static -Ofast -mavx
+CXXFLAGS+=-I..  -static -Ofast -march=native
 
 all: $(BINS)
 


### PR DESCRIPTION
-march=native automatically select -mavx if it is supported by host platform, so the test could be build if AVX is not supported.
-march=native is available starting from gcc 4.7
